### PR TITLE
Colorize yasnippet trigger key like in helm-M-x

### DIFF
--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -252,12 +252,8 @@ like `yas--current-key'"
                                       for name = (car dotlst)
                                       for template = (cdr dotlst)
                                       for key = (helm-yas-get-key-by-template template alist)
-                                      collect `(,(format "[%s] %s"
-                                                         (propertize
-                                                          key
-                                                          'face 'helm-yas-key)
-                                                         name)
-                                                . ,template))))
+                                      for name-inc-key = (concat "[" (propertize key 'face 'helm-yas-key) "] " name)
+                                      collect `(,name-inc-key . ,template))))
 
      ;; default ex: for (...) { ... }
      (t

--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -113,7 +113,7 @@ ex. for (...) { ... }"
 
 (defface helm-yas-key '((t (:foreground "orange" :underline t)))
   "Face used in helm-yas-complete to show key triggers."
-  :group 'helm-command-faces)
+  :group 'helm-yasnippet)
 
 (defvar helm-yas-cur-snippets-alist nil)
 

--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -111,6 +111,10 @@ ex. for (...) { ... }"
   :type 'function
   :group 'helm-yasnippet)
 
+(defface helm-yas-key '((t (:foreground "orange" :underline t)))
+  "Face used in helm-yas-complete to show key triggers."
+  :group 'helm-command-faces)
+
 (defvar helm-yas-cur-snippets-alist nil)
 
 (defun helm-yas-create-new-snippet-insert (selected-text snippet-file)
@@ -248,8 +252,13 @@ like `yas--current-key'"
                                       for name = (car dotlst)
                                       for template = (cdr dotlst)
                                       for key = (helm-yas-get-key-by-template template alist)
-                                      for name-inc-key = (concat "[" key "] " name)
-                                      collect `(,name-inc-key . ,template))))
+                                      collect `(,(format "[%s] %s"
+                                                         (propertize
+                                                          key
+                                                          'face 'helm-yas-key)
+                                                         name)
+                                                . ,template))))
+
      ;; default ex: for (...) { ... }
      (t
       (setq transformed-list (cl-remove-if-not (lambda (lst)


### PR DESCRIPTION
Thanks for creating helm-c-yasnippet, I find it really useful.

This PR adds color to the yasnippet trigger key shown in the helm interface. Pretty much the same that helm-M-x does. In fact, I used basically the same code as helm-M-x.

I find this feature very useful because it highlights the trigger and helps me to remember it so next time I won't have to use helm.

Thanks for considering my PR.
