### PR TITLE
Prefix "cl-" to multiple-value-setq, values, and return

### DIFF
--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -169,10 +169,10 @@ If SNIPPET-FILE does not contain directory, it is placed in default snippet dire
              do (if (and (funcall predfunc file)
                          (string-match regexp file))
                     (progn (setq found t)
-                           (return (file-name-as-directory file)))
+                           (cl-return (file-name-as-directory file)))
                   (when (file-directory-p file)
                     (setq result (helm-yas-find-recursively regexp file predicate))))
-             finally (return result))))
+             finally (cl-return result))))
 
 
 (defun helm-yas-build-cur-snippets-alist (&optional table)
@@ -229,8 +229,8 @@ like `yas--current-key'"
             (error ""))
           (skip-syntax-backward syntax)
           (setq start (point))
-          (values (buffer-substring-no-properties start end) start end))
-      (error (values "" (point) (point))))))
+          (cl-values (buffer-substring-no-properties start end) start end))
+      (error (cl-values "" (point) (point))))))
 
 (defun helm-yas-get-key-by-template (template alist) ;str template
   "Return key"
@@ -296,7 +296,7 @@ space match anyword greedy"
   `((name . "Yasnippet")
     (init . (lambda ()
               (setq helm-yas-selected-text (if mark-active (buffer-substring-no-properties (region-beginning) (region-end)) ""))
-              (multiple-value-setq
+              (cl-multiple-value-setq
                (helm-yas-initial-input helm-yas-point-start helm-yas-point-end) (helm-yas-get-cmp-context)) ;return values(str point point)
               (setq helm-yas-cur-snippets-alist (helm-yas-build-cur-snippets-alist))))
     (candidates . (helm-yas-get-candidates helm-yas-cur-snippets-alist))


### PR DESCRIPTION
I encountered the error saying "Symbol's function definition is void: multiple-value-setq" when calling `helm-yas-complete`. Here is my emacs version:

> GNU Emacs 24.5.1 (x86_64-pc-linux-gnu, GTK+ Version 3.18.9) of 2016-04-17 on lgw01-04, modified by Debian

This PR resolves this error.

In addition, the following warning shown on byte-compilation is handled.

```
In end of data:
helm-c-yasnippet.el:416:1:Warning: the following functions are not known to be
      defined: return, values
```
