### PR TITLE
Fix escaping of path in helm-yas-create-new-snippet

### DIFF
--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -136,11 +136,11 @@ ex. for (...) { ... }"
   "Create snippet from SELECTED-TEXT into SNIPPET-FILE.
 If SNIPPET-FILE is nil, asks file name.
 If SNIPPET-FILE does not contain directory, it is placed in default snippet directory."
-  (let* ((major-mode-dir (regexp-quote (symbol-name major-mode)))
-         (yas-dir (expand-file-name (or (car-safe yas-snippet-dirs) yas-snippet-dirs)))
+  (let* ((major-mode-dir (symbol-name major-mode))
+         (yas-dir (file-name-as-directory (expand-file-name (or (car-safe yas-snippet-dirs) yas-snippet-dirs))))
          (snippet-dir
-          (or (helm-yas-find-recursively major-mode-dir yas-dir 'snippet-file)
-              (let ((target-dir (format "%s/%s/" yas-dir major-mode-dir)))
+          (or (helm-yas-find-recursively (regexp-quote major-mode-dir) yas-dir 'snippet-file)
+              (let ((target-dir (file-name-as-directory (concat yas-dir major-mode-dir))))
                 (if (yes-or-no-p (format "%s doesn't exist. Would you like to create this directory?" target-dir))
                     (progn
                       (make-directory target-dir)


### PR DESCRIPTION
The `helm-yas-create-new-snippet` function was using `regexp-quote` on `major-mode` to check if the directory for this mode was present in the snippets directory. However, this quoted version of the mode was also used when actually creating the path, which gave some weird behaviour. In particular, I was unable to use this function when in c++-mode, as that was escaped to `c\+\+-mode`.

Also fixes a minor portability issue.