### PR TITLE
Ignore eval candition error

### DIFF
--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -209,7 +209,7 @@ If SNIPPET-FILE does not contain directory, it is placed in default snippet dire
                  for file = (yas--template-load-file template-struct) ;`yas--template-content'
                  for condition = (yas--template-condition template-struct)
                  for expand-env = (yas--template-expand-env template-struct)
-                 when (or (not condition) (eval condition))
+                 when (or (not condition) (ignore-error (eval condition)))
                  do (progn (push template templates)
                            (push `(,name . ,template) transformed)
                            (push `(,template . ,key) template-key-alist)


### PR DESCRIPTION
Conditions of some snippets raises an error. For example,
some javascript snippets uses js2-mode function for testing AST
and it raises an exception. helm-c-yasnippet should ignore it.

This is related to https://github.com/emacs-jp/helm-c-yasnippet/issues/23#issuecomment-808888531