### PR TITLE
Fix helm-yas-find-recursively

### DIFF
--- a/helm-c-yasnippet.el
+++ b/helm-c-yasnippet.el
@@ -167,7 +167,7 @@ If SNIPPET-FILE does not contain directory, it is placed in default snippet dire
     (cl-loop for file in files
              unless found
              do (if (and (funcall predfunc file)
-                         (string-match regexp file))
+                         (string-equal regexp (file-name-base file)))
                     (progn (setq found t)
                            (cl-return (file-name-as-directory file)))
                   (when (file-directory-p file)


### PR DESCRIPTION
Steps to reproduce the issue:

```sh
$ ls -1 ~/.emacs.d/snippets
...
fish-mode
sh-mode
...

$ emacs -Q --batch --eval "\
  (progn
    (setq user-emacs-directory \"~/.emacs.d/29.1/\")
    (setq package-user-dir (concat user-emacs-directory \"elpa/\"))
    (package-initialize)
    (require 'yasnippet)
    (require 'helm)
    (require 'helm-c-yasnippet)
    (print (helm-yas-find-recursively (symbol-name 'sh-mode) \"~/.emacs.d/snippets/\" 'snippet-file)))"

"/Users/*/.emacs.d/snippets/fish-mode/"
```

Expected:

    "/Users/*/.emacs.d/snippets/sh-mode/"

Actual:

    "/Users/*/.emacs.d/snippets/fish-mode/"
